### PR TITLE
🔖 v0.0.9 - Deploy-AdxObject multiple batch support

### DIFF
--- a/Functions/Deploy-AdxObject.ps1
+++ b/Functions/Deploy-AdxObject.ps1
@@ -18,6 +18,7 @@ function Deploy-AdxObject {
 
     $Command = Get-Content $FilePath -Raw
 
+    # also matches `.create-merge`, `.create-or-alter`, etc...
     $FirstControlWord = ([char[]]($Command -replace "[\s\n\r]"))[0 .. 6] -join ''
 
     if('.create' -eq $FirstControlWord){

--- a/Functions/Deploy-AdxObject.ps1
+++ b/Functions/Deploy-AdxObject.ps1
@@ -13,13 +13,23 @@ function Deploy-AdxObject {
 
         [Parameter(Mandatory)]
         [string]
-        $DatabaseName
+        $DatabaseName,
+
+        [Parameter()]
+        [switch]
+        $ContinueOnErrors
     )
 
     $Command = Get-Content $FilePath -Raw
 
     # also matches `.create-merge`, `.create-or-alter`, etc...
     $FirstControlWord = ([char[]]($Command -replace "[\s\n\r]"))[0 .. 6] -join ''
+
+    $IsMultiBatch = $Command -match '\r\n\r\n'
+    if($IsMultiBatch){
+        Write-Verbose "More than one batch detected in deployment script. Commands will be wrapped in an `.execute` block."
+        $Command = ".execute database script with (ContinueOnErrors=$ContinueOnErrors) <| `n$Command"
+    }
 
     if('.create' -eq $FirstControlWord){
         Invoke-AdxCmd -ClusterUrl $ClusterUrl -DatabaseName $DatabaseName -Command $Command

--- a/Invoke-AdxCmd.psd1
+++ b/Invoke-AdxCmd.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'Invoke-AdxCmd.psm1'
-    ModuleVersion = '0.0.8'
+    ModuleVersion = '0.0.9'
     Author = 'Peter Vandivier'
     FunctionsToExport = @(
         'Invoke-AdxCmd'


### PR DESCRIPTION
KQL terminates a statement on 2 newlines. A version control script file might include a table definition followed by a retention policy and an update policy. These are 3 separate batches. When this is encountered, wrap all batches in an [`.execute`](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/execute-database-script) block.

TODO:
* better multi-batch detection
* ¿add multi-batch detection/support to `Invoke-AdxCmd`?
* better returned resultset from `.execute` (¿include object name?)