### PR TITLE
🔖 v0.0.10 - policy support in `.create table` output

### DIFF
--- a/Assets/KqlKeywords.csv
+++ b/Assets/KqlKeywords.csv
@@ -1,0 +1,7 @@
+Word,IsReserved,IsTested,SourceId,SourceSlug,Comments
+in,false,true,1,scalar-data-types/dynamic,
+value,false,true,1,scalar-data-types/dynamic,
+array,false,true,1,scalar-data-types/dynamic,
+array_length,false,true,1,scalar-data-types/dynamic,
+where,false,true,1,scalar-data-types/dynamic,Noted as a keyword but testing reveals it is a valid EntityName
+take,false,true,,,

--- a/Assets/ReadMe.md
+++ b/Assets/ReadMe.md
@@ -1,0 +1,3 @@
+# Static Assets
+
+Miscellaneous lookup files needed for reference.

--- a/Assets/Sources.csv
+++ b/Assets/Sources.csv
@@ -1,0 +1,2 @@
+Id,Slug,Url
+1,scalar-data-types/dynamic,https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/scalar-data-types/dynamic#dynamic-object-accessors

--- a/Functions/ConvertTo-AdxCreateTableCmd.ps1
+++ b/Functions/ConvertTo-AdxCreateTableCmd.ps1
@@ -1,23 +1,107 @@
 
 function ConvertTo-AdxCreateTableCmd {
-    [CmdletBinding()]
+<#
+.Synopsis
+    Returns a valid `.create table` command from DB-supplied `cslschema` input
+
+.Description
+    Does not make any database calls. Takes input well-formed from a prior database
+    call (or mocked to match) and formats it to valid KQL DDL.
+
+    Suffix Retention & Caching policy statements as needed. That is: if-and-only-if
+    table-level policies differ from database defaults. For this however, we must
+    require that database defaults be supplied.
+
+.Parameter CslSchemaDataRow
+    Incoming column names from `.show database cslschema` are already quoted as needed.
+    Table names from the same input are _not_ likewise quotenamed and must be processed
+    through `Format-KqlIdentifier`
+#>
+    [CmdletBinding(DefaultParameterSetName='Schema')]
     param (
-        [Parameter(ValueFromPipeline)]
+        [Parameter(
+            ValueFromPipeline,
+            Mandatory,
+            ParameterSetName='Schema'
+        )]
+        [Parameter(
+            ValueFromPipeline,
+            Mandatory,
+            ParameterSetName='Policies'
+        )]
         [AdxTableCslSchemaDatarow]
-        $CslSchemaDataRow
+        $CslSchemaDataRow,
+
+        [Parameter(
+            Mandatory,
+            ParameterSetName='Policies'
+        )]
+        $TablesDetails,
+
+        [Parameter(
+            Mandatory,
+            ParameterSetName='Policies'
+        )]
+        $DatabasePolicies
     )
     $createStub = ".create-merge table {TableName} (`n{ColumnList}`n) {WithClause}"
+    $TableName = $CslSchemaDataRow.TableName | Format-KqlIdentifier
 
     $WithClause = New-KqlWithClause $CslSchemaDataRow.Folder $CslSchemaDataRow.DocString
     $ColumnList = ($CslSchemaDataRow.Schema.Split(',') | ForEach-Object {
         "    $($_.Replace(':', ': '))"
     }) -join ",$([Environment]::NewLine)"
     $createCmd = $createStub.Replace(
-        '{TableName}', $CslSchemaDataRow.TableName
+        '{TableName}', $TableName
     ).Replace(
         '{ColumnList}', $ColumnList
     ).Replace(
         '{WithClause}', $WithClause
     )
+
+    if($PsCmdlet.ParameterSetName -eq 'Policies'){
+        $DatabaseCachingPolicy = $DatabasePolicies.CachingPolicy | ConvertFrom-Json
+        $TablesCachingPolicy = $TablesDetails.CachingPolicy | ConvertFrom-Json
+        if(
+            ($DatabaseCachingPolicy.DataHotSpan.Value -ne $TablesCachingPolicy.DataHotSpan) -or
+            ($DatabaseCachingPolicy.IndexHotSpan.Value -ne $TablesCachingPolicy.IndexHotSpan)
+        ){
+            # https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/alter-table-cache-policy-command
+            if($TablesCachingPolicy.DataHotSpan -eq $TablesCachingPolicy.IndexHotSpan){
+                $CachingPolicy = ".alter table $TableName policy caching hot = timespan($($TablesCachingPolicy.DataHotSpan))"
+            } else {
+                $CachingPolicy = @(
+                    ".alter table $TableName policy caching"
+                    "    hotdata = timespan($($TablesCachingPolicy.DataHotSpan))"
+                    "    hotindex = timespan($($TablesCachingPolicy.IndexHotSpan))"
+                ) -join [Environment]::NewLine
+            }
+
+            $createCmd += [Environment]::NewLine * 2
+            $createCmd += $CachingPolicy
+        }
+
+        $DatabaseRetentionPolicy = $DatabasePolicies.RetentionPolicy | ConvertFrom-Json
+        $TablesRetentionPolicy =  $TablesDetails.RetentionPolicy | ConvertFrom-Json
+        if(
+            ($DatabaseRetentionPolicy.SoftDeletePeriod -ne $TablesRetentionPolicy.SoftDeletePeriod) -or
+            ($DatabaseRetentionPolicy.Recoverability -ne $TablesRetentionPolicy.Recoverability)
+        ){
+            # https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/alter-table-retention-policy-command
+            $RetentionPolicy = @(
+                ".alter table $TableName policy retention"
+                '```'
+                [PsCustomObject]@{
+                    SoftDeletePeriod = $TablesRetentionPolicy.SoftDeletePeriod
+                    Recoverability = $TablesRetentionPolicy.Recoverability
+                } | ConvertTo-Json
+                '```'
+            ) -join [Environment]::NewLine 
+
+            $createCmd += [Environment]::NewLine * 2
+            $createCmd += $RetentionPolicy
+        }
+    }
+
     return $createCmd
 }

--- a/Functions/Format-KqlIdentifier.ps1
+++ b/Functions/Format-KqlIdentifier.ps1
@@ -1,0 +1,37 @@
+function Format-KqlIdentifier {
+<#
+.Synopsis
+    Takes a string and `quotename`s it IF NEEDED to be a valid KQL identifier
+
+.Link
+    https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/schema-entities/entity-names
+
+.Outputs
+    [string]
+#>
+    [CmdletBinding()]
+    param (
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline
+        )]
+        [ValidateLength(1,1024)]
+        [string]
+        $Identifier
+    )
+
+    if(Test-KqlKeyword $Identifier){
+        return "['$Identifier']"
+    }
+
+    if($Identifier -match '[^a-zA-Z0-9_]'){
+        return "['$Identifier']"
+    }
+
+    if($Identifier.StartsWith('__')){
+        # n.b. docs indicate `.EndsWith('__')` as an invalid format, but testing belies this
+        throw "The Kusto Query Language reserves all identifiers that start with a sequence of two underscore characters (__); users can't define such names for their own use."
+    }
+
+    return $Identifier
+}

--- a/Functions/Test-KqlKeyword.ps1
+++ b/Functions/Test-KqlKeyword.ps1
@@ -1,0 +1,28 @@
+function Test-KqlKeyword {
+<#
+.Synopsis
+    Tests whether the input is a known KQL reserved keyword.
+
+.Description
+    TODO: make this list more exhaustive. See StackOverflow post linked below.
+
+.Link
+    https://stackoverflow.com/questions/76783075/what-are-the-kql-reserved-keywords
+
+.Outputs
+    [bool]
+#>
+    [CmdletBinding()]
+    param (
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline
+        )]
+        [string]
+        $Word
+    )
+
+    $IsReservedKeyword = $Word -in $KqlReservedKeywords
+
+    return $IsReservedKeyword
+}

--- a/Invoke-AdxCmd.psd1
+++ b/Invoke-AdxCmd.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'Invoke-AdxCmd.psm1'
-    ModuleVersion = '0.0.9'
+    ModuleVersion = '0.0.10'
     Author = 'Peter Vandivier'
     FunctionsToExport = @(
         'Invoke-AdxCmd'
@@ -11,8 +11,13 @@
         'Deploy-AdxObject'
         'Export-AdxDatabaseSchema'
         'Export-AdxTableData'
+        'Format-KqlIdentifier'
         'Format-KqlParameters'
         'New-KqlWithClause'
+        'Test-KqlKeyword'
+    )
+    VariablesToExport = @(
+        'KqlReservedKeywords'
     )
     Guid = '688fd570-0253-491b-beff-385ecc05cef2'
 }

--- a/Invoke-AdxCmd.psm1
+++ b/Invoke-AdxCmd.psm1
@@ -18,4 +18,11 @@ Get-ChildItem Functions -Filter *.ps1 | ForEach-Object {
     Export-ModuleMember $_.BaseName
 }
 
+Import-Csv "Assets/KqlKeywords.csv"
+| Where-Object IsReserved -eq 'TRUE'
+| Select-Object -ExpandProperty Word
+| Set-Variable -Name KqlReservedKeywords -Option ReadOnly -Force
+
+Export-ModuleMember -Variable KqlReservedKeywords
+
 Pop-Location


### PR DESCRIPTION
- 🚀 adds support for retention policy & caching policy in `.create table`
  - 🔇 Only includes policy command when the table setting differs from the database default
- ✨ quotenames identifiers if needed
- 💩 keyword placeholder
  - 🍱 keyword lookup (manually cultivated for now) - https://stackoverflow.com/q/76783075/4709762